### PR TITLE
add option for memory predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ plugins {
 | strategy | - | Which strategy should be used for scheduling; available strategies depend on the CWS instance |
 | costFunction | - | Which cost function should be used for scheduling; available strategies depend on the CWS instance |
 | batchSize | - | Number of tasks to submit together (only if more than this are ready to run); default: 1 |
+| memoryPredictor | - | The memory predictor that shall be used for task scaling. <br>If not set, task scaling is disabled. See Common Workflow Scheduler for supported predictors. |
 
 ##### Example: 
 ```

--- a/plugins/nf-cws/src/main/nextflow/cws/CWSConfig.groovy
+++ b/plugins/nf-cws/src/main/nextflow/cws/CWSConfig.groovy
@@ -17,6 +17,8 @@ class CWSConfig {
 
     String getCostFunction() { target.costFunction as String }
 
+    String getMemoryPredictor() { target.memoryPredictor as String }
+
     int getBatchSize() {
         String s = target.batchSize as String
         //Default: 1 -> No batching

--- a/plugins/nf-cws/src/main/nextflow/cws/k8s/CWSK8sExecutor.groovy
+++ b/plugins/nf-cws/src/main/nextflow/cws/k8s/CWSK8sExecutor.groovy
@@ -87,6 +87,7 @@ class CWSK8sExecutor extends K8sExecutor implements ExtensionPoint {
                     volumeClaims : podOptions.volumeClaims,
                     traceEnabled : traceEnabled,
                     costFunction : cwsConfig.getCostFunction(),
+                    memoryPredictor : cwsConfig.getMemoryPredictor(),
                     additional   : cwsK8sConfig.getAdditional()
             ]
         } else {


### PR DESCRIPTION
I've tried to use the 'additional' way to transfer my configuration to the cws, but it did not work. Maybe there is somethings wrong, with that?

I believe the right spot to put that would be in the cws-config block anyway.

Could you approve that and release this together with the other changes since 1.0.3, as a new version 1.0.4 please?