### PR TITLE
Use new Nextflow pod names

### DIFF
--- a/plugins/nf-cws/src/main/nextflow/cws/k8s/CWSK8sTaskHandler.groovy
+++ b/plugins/nf-cws/src/main/nextflow/cws/k8s/CWSK8sTaskHandler.groovy
@@ -61,6 +61,7 @@ class CWSK8sTaskHandler extends K8sTaskHandler {
         super.newSubmitRequest(task)
     }
 
+    @Override
     protected Map newSubmitRequest0(TaskRun task, String imageName) {
         Map<String, Object> pod = super.newSubmitRequest0(task, imageName)
         if ( (k8sConfig as CWSK8sConfig)?.getScheduler() ){


### PR DESCRIPTION
This PR allows the nf-cws plugin to deal with the new Nextflow pod names of the form `nf-<hash>-<currentTime-suffix>`.
Instead of generating pod names ourselves, we now read the pod name generated by Nextflow.