### PR TITLE
Document Usage with new nf-k8s plugin for >=25.03.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ plugins {
 }
 ```
 
-For Nextflow versions >=`25.03.0`, the `nf-k8s` plugin is required.
-`nf-cws` will try to automatically start the `nf-k8s` plugin for you, if required.
-Still, you may be better off adding it to your call or the config explicitly.
-
 ### Configuration
 
 |    Attribute    | Required | Explanation                                                                                                                                                                      |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ see the [scheduler repository](https://github.com/CommonWorkflowScheduler/Kubern
 ### How to use
 
 To run Nextflow with this plugin, you need version >=`24.04.0`.
-To activate the plugin, add `-plugins nf-cws` to your `nextflow` call, or add the following to your `nextflow.config`:
+To activate the plugin, add `-plugins nf-cws` to your `nextflow` call or add the following to your `nextflow.config`:
 ```
 plugins {
   id 'nf-cws'

--- a/README.md
+++ b/README.md
@@ -17,22 +17,17 @@ see the [scheduler repository](https://github.com/CommonWorkflowScheduler/Kubern
 
 ### How to use
 
-To run Nextflow with this plugin, you need version >=`24.04.0` and the nf-k8s plugin is required for Nextflow versions >=`25.03.0`.
-To activate the plugin, add `-plugins nf-k8s nf-cws` (or just `-plugins nf-cws` in older versions) to your `nextflow` call,
-or add the following to your `nextflow.config`:
+To run Nextflow with this plugin, you need version >=`24.04.0`.
+To activate the plugin, add `-plugins nf-cws` to your `nextflow` call, or add the following to your `nextflow.config`:
+```
+plugins {
+  id 'nf-cws'
+}
+```
 
-```
-plugins {
-  id 'nf-k8s'
-  id 'nf-cws'
-}
-```
-or in older versions just:
-```
-plugins {
-  id 'nf-cws'
-}
-```
+For Nextflow versions >=`25.03.0`, the `nf-k8s` plugin is required.
+`nf-cws` will try to automatically start the `nf-k8s` plugin for you, if required.
+Still, you may be better off adding it to your call or the config explicitly.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,17 @@ see the [scheduler repository](https://github.com/CommonWorkflowScheduler/Kubern
 
 ### How to use
 
-To run Nextflow with this plugin, you need version >=`24.04.0` and <=`25.02.3-edge`
-(because Nextflow's Kubernetes refactor in `25.03.0-edge` is not supported *yet*).
-To activate the plugin, add `-plugins nf-cws` to your `nextflow` call or add the following to your `nextflow.config`:
+To run Nextflow with this plugin, you need version >=`24.04.0` and the nf-k8s plugin is required for Nextflow versions >=`25.03.0`.
+To activate the plugin, add `-plugins nf-k8s nf-cws` (or just `-plugins nf-cws` in older versions) to your `nextflow` call,
+or add the following to your `nextflow.config`:
 
+```
+plugins {
+  id 'nf-k8s'
+  id 'nf-cws'
+}
+```
+or in older versions just:
 ```
 plugins {
   id 'nf-cws'

--- a/plugins/nf-cws/src/main/nextflow/cws/CWSPlugin.groovy
+++ b/plugins/nf-cws/src/main/nextflow/cws/CWSPlugin.groovy
@@ -9,6 +9,7 @@ import nextflow.cws.wow.filesystem.WOWFileSystemProvider
 import nextflow.cws.wow.serializer.LocalPathSerializer
 import nextflow.file.FileHelper
 import nextflow.plugin.BasePlugin
+import nextflow.plugin.Plugins
 import nextflow.trace.TraceRecord
 import nextflow.util.KryoHelper
 import org.pf4j.PluginWrapper
@@ -68,13 +69,7 @@ class CWSPlugin extends BasePlugin {
                 .checkVersionConstraint(BuildInfo.version, ">=25.03.0")
 
         if ( isK8sPluginVersion ) {
-            PluginWrapper searchResultNfK8s = getWrapper()
-                .getPluginManager()
-                .getPlugins()
-                .find { it.getPluginId() == 'nf-k8s' }
-            if ( searchResultNfK8s == null ) {
-                throw new IllegalStateException("The 'nf-k8s' plugin is required by nf-cws but not loaded.")
-            }
+            Plugins.startIfMissing('nf-k8s')
         }
     }
 

--- a/plugins/nf-cws/src/main/nextflow/cws/CWSPlugin.groovy
+++ b/plugins/nf-cws/src/main/nextflow/cws/CWSPlugin.groovy
@@ -63,11 +63,10 @@ class CWSPlugin extends BasePlugin {
 
     private checkForK8sPlugin() {
         // in 25.03.0-edge, Nextflow's Kubernetes functionality was refactored into a plugin
-        boolean isK8sPluginVersion =  getWrapper()
+        boolean isK8sPluginVersion = getWrapper()
                 .getPluginManager()
                 .getVersionManager()
                 .checkVersionConstraint(BuildInfo.version, ">=25.03.0")
-
         if ( isK8sPluginVersion ) {
             Plugins.startIfMissing('nf-k8s')
         }


### PR DESCRIPTION
This PR just adds some description of how to use `nf-cws` with the new `nf-k8s` plugin for the newest Nextflow versions.